### PR TITLE
npm-scripts-help improvement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6454,9 +6454,9 @@
       }
     },
     "npm-scripts-help": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/npm-scripts-help/-/npm-scripts-help-0.7.0.tgz",
-      "integrity": "sha1-9W147FiyEsGhQvVtbbNud8AcnKg=",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/npm-scripts-help/-/npm-scripts-help-0.8.0.tgz",
+      "integrity": "sha512-OObggOki7LYbq7X2PDzaNXzpqajJt8jwGMJYfwhyzsrJoeaJnWovhLTZMYC3nYuD6r8WxpwdjE7vS4qkD0BFOw==",
       "dev": true,
       "requires": {
         "chalk": "1.1.3"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "docker:make": "./make",
     "docker:start": "./start",
     "docker:stop": "./stop",
-    "help": "node node_modules/npm-scripts-help"
+    "help": "npm-scripts-help"
   },
   "scriptshelp": {
     "dev": "start dev server (default port to 8080)",
@@ -71,7 +71,7 @@
     "jest": "^21.2.1",
     "lint-staged": "^6.0.1",
     "nodemon": "^1.12.1",
-    "npm-scripts-help": "^0.7.0",
+    "npm-scripts-help": "^0.8.0",
     "path": "^0.12.7",
     "rimraf": "^2.6.2"
   },

--- a/package.json
+++ b/package.json
@@ -27,15 +27,19 @@
     "help": "npm-scripts-help"
   },
   "scriptshelp": {
-    "dev": "start dev server (default port to 8080)",
-    "start": "start production server (default port to 8000)",
-    "test": "start server tests",
+    "dev": "start development barbe-ci daemon (default port to 8080)",
+    "start": "start production barbe-ci daemon (default port to 8000)",
+    "clean": "clean artifacts and reports",
+    "commit": "make a commit using git commitizen",
+    "test": "start unit tests",
+    "test:watch": "start unit tests (in watch mode)",
+    "test:coverage": "start unit tests (with coverage report)",
+    "test:all": "start all kinds of tests (lint, unit, ...)",
     "lint": "lint all files in src/ folder",
-    "release": "bump version and make a release",
-    "docker:make": "build server docker image for production",
-    "docker:start": "start api on port 8081",
-    "docker:stop": "stop api",
-    "help": "show this help"
+    "bump": "bump version (for release only)",
+    "docker:make": "build barbe-ci docker image for production",
+    "docker:start": "start barbe-ci daemon on port 8081",
+    "docker:stop": "stop barbe-ci daemon"
   },
   "lint-staged": {
     "*.js": [


### PR DESCRIPTION
- Update `npm-scripts-help` to v0.8.0
- Write missing "scriptshelp" usage